### PR TITLE
feat: disable GPT button when loading

### DIFF
--- a/src/components/chatRoom/ChatTaskGenerator.tsx
+++ b/src/components/chatRoom/ChatTaskGenerator.tsx
@@ -5,11 +5,7 @@ import UpgradeDialogContent from "@/components/user/UpgradeDialogContent";
 import { useUserContext } from "@/context/UserContext";
 import UserPlanEnum from "@/models/enums/UserPlanEnum";
 
-interface ChatTaskGeneratorProps {
-    disabled?: boolean;
-}
-
-const ChatTaskGenerator = ({ disabled = false }: ChatTaskGeneratorProps) => {
+const ChatTaskGenerator = ({ loading = false }: { loading: boolean }) => {
     const [open, setOpen] = useState(false);
     const { userPlan } = useUserContext();
 
@@ -19,7 +15,7 @@ const ChatTaskGenerator = ({ disabled = false }: ChatTaskGeneratorProps) => {
                 <Button
                     onClick={() => setOpen(true)}
                     color={userPlan === UserPlanEnum.Free ? "gray" : "blue"}
-                    disabled={disabled}
+                    disabled={loading}
                 >
                     gpt +
                 </Button>

--- a/src/components/chatRoom/ChatTaskGenerator.tsx
+++ b/src/components/chatRoom/ChatTaskGenerator.tsx
@@ -5,7 +5,11 @@ import UpgradeDialogContent from "@/components/user/UpgradeDialogContent";
 import { useUserContext } from "@/context/UserContext";
 import UserPlanEnum from "@/models/enums/UserPlanEnum";
 
-const ChatTaskGenerator = () => {
+interface ChatTaskGeneratorProps {
+    disabled?: boolean;
+}
+
+const ChatTaskGenerator = ({ disabled = false }: ChatTaskGeneratorProps) => {
     const [open, setOpen] = useState(false);
     const { userPlan } = useUserContext();
 
@@ -15,6 +19,7 @@ const ChatTaskGenerator = () => {
                 <Button
                     onClick={() => setOpen(true)}
                     color={userPlan === UserPlanEnum.Free ? "gray" : "blue"}
+                    disabled={disabled}
                 >
                     gpt +
                 </Button>

--- a/src/components/flows/ModeSelector.tsx
+++ b/src/components/flows/ModeSelector.tsx
@@ -1,5 +1,6 @@
 import ChatTaskGenerator from "@/components/chatRoom/ChatTaskGenerator";
 import { useProjectContext } from "@/context/ProjectContext";
+import { useTaskContext } from "@/context/TaskContext";
 import ListMode from "@/models/enums/ListMode";
 import { Flex, Select, Text } from "@radix-ui/themes";
 
@@ -10,14 +11,17 @@ const ModeSelector = ({
     mode: ListMode;
     setMode: (mode: ListMode) => void;
 }) => {
-    const { currentProject } = useProjectContext();
+    const { currentProject, loading: projectLoading } = useProjectContext();
+    const { loading: taskLoading } = useTaskContext();
+    
+    const isLoading = projectLoading || taskLoading;
 
     return (
         <div className="px-6 py-4 border-b border-zinc-800 text-sm font-semibold bg-zinc-900">
             <Flex justify="between">
                 <Text>{currentProject?.id}</Text>
                 <Flex gapX="4">
-                    <ChatTaskGenerator />
+                    <ChatTaskGenerator disabled={isLoading} />
                     <Select.Root
                         value={mode}
                         onValueChange={(m) => setMode(m as ListMode)}

--- a/src/components/flows/ModeSelector.tsx
+++ b/src/components/flows/ModeSelector.tsx
@@ -13,7 +13,7 @@ const ModeSelector = ({
 }) => {
     const { currentProject, loading: projectLoading } = useProjectContext();
     const { loading: taskLoading } = useTaskContext();
-    
+
     const isLoading = projectLoading || taskLoading;
 
     return (
@@ -21,7 +21,7 @@ const ModeSelector = ({
             <Flex justify="between">
                 <Text>{currentProject?.id}</Text>
                 <Flex gapX="4">
-                    <ChatTaskGenerator disabled={isLoading} />
+                    <ChatTaskGenerator loading={isLoading} />
                     <Select.Root
                         value={mode}
                         onValueChange={(m) => setMode(m as ListMode)}


### PR DESCRIPTION
- Add disabled prop to ChatTaskGenerator component
- Pass loading state from TaskContext and ProjectContext to ChatTaskGenerator
- GPT button is disabled when either task or project operations are loading
- Prevents multiple simultaneous GPT requests during loading states